### PR TITLE
feat(all-scripts): Introduce semi-consistent logging in the scripts

### DIFF
--- a/Deregister-WSL2-Backup.ps1
+++ b/Deregister-WSL2-Backup.ps1
@@ -7,6 +7,10 @@ distribution is "Ubuntu".
 The naming convention for the script follows the spelling suggestion correction for 'unregister'. 
 However, the powershell module that actually performs the removal of the tasks either follows a
 different dictionary, or ignores suggested spelling for that activity.
+
+Note: output redirection can be used to get a more informative output by exposing the log messages when appending '6>&1' 
+to the end of script invocation whether arguments are specified or not
+
 .EXAMPLE
 # remove a task that is targetting a default distribution called 'Ubuntu'
 .\Deregister-WSL2-Backup.ps1
@@ -19,19 +23,26 @@ param(
     [string]$distribution = 'Ubuntu'
 )
 
+# 'sourcing' in the log message function
+. "$PSScriptRoot\Log-Message.ps1"
+
 
 $taskName = "WSL2 $distribution backup"
 
 try {
+    Log "Unregistering scheduled task $taskName"
     Unregister-ScheduledTask -TaskName $taskName
+    Log "Scheduled task $taskName unregistered"
 }
 catch {
-    Write-Output "Unable to remove any tasks named $taskName"
+    Log "Unable to remove any tasks named $taskName" -LogLevel Warning
 }
 
 try {
+    Log "Unregistering scheduled task 'Restart Docker'"
     Unregister-ScheduledTask -TaskName 'Restart Docker'
+    Log "Scheduled task 'Restart Docker' unregistered"
 }
 catch {
-    Write-Output 'Unable to remove any tasks named Restart Docker'
+    Log "Unable to remove any tasks named 'Restart Docker'" -LogLevel Warning
 }

--- a/Get-Scheduled-WSL2-Backups.ps1
+++ b/Get-Scheduled-WSL2-Backups.ps1
@@ -4,6 +4,9 @@ The script queries all scheduled tasks the current user has permission to view t
 .DESCRIPTION
 The script queries all scheduled tasks the current user has permission to view that match the given distribution. 
 By default it matches all WSL2 backup tasks that contain "WSL2 * backup" and all "Docker" tasks.
+
+Note: output redirection can be used to get a more informative output by exposing the log messages when appending '6>&1' 
+to the end of script invocation whether arguments are specified or not
 .EXAMPLE
 # list all task that are targeting any distribution
 .\Get-Scheduled-WSL2-Backups.ps1 -distribution *
@@ -17,8 +20,15 @@ param (
     $distribution = '*'
 )
 
+# 'sourcing' in the log message function
+. "$PSScriptRoot\Log-Message.ps1"
+
+Log "Getting a list of scheduled tasks that match $backupTaskName and *Docker*"
+
 $backupTaskName = "WSL2 $distribution backup"
 Get-ScheduledTask -TaskName $backupTaskName
 
 $restartDockerTaskName = '*Docker*'
 Get-ScheduledTask -TaskName $restartDockerTaskName
+
+Log "Scheduled tasks that match $backupTaskName and *Docker* listed above"

--- a/Log-Message.ps1
+++ b/Log-Message.ps1
@@ -8,7 +8,7 @@ function Log {
         [string]$LogLevel = 'Information'
     )
 
-    $timestamp = $(Get-Date -Format FileDateTime)
+    $timestamp = $(Get-Date -Format "HH:mm:ss")
     $logMessageFormatted = "$timestamp - $Message"
 
     switch ($LogLevel) {

--- a/Log-Message.ps1
+++ b/Log-Message.ps1
@@ -1,0 +1,34 @@
+function Log {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message,
+        [Parameter(Mandatory = $false, Position = 1)]
+        [ValidateSet('Error', 'Warning', 'Information', 'Verbose', 'Debug')]
+        [string]$LogLevel = 'Information'
+    )
+
+    $timestamp = $(Get-Date -Format FileDateTime)
+    $logMessageFormatted = "$timestamp - $Message"
+
+    switch ($LogLevel) {
+        'Error' { 
+            Write-Error -Message $logMessageFormatted
+        }
+        'Warning' { 
+            Write-Warning -Message $logMessageFormatted
+        }
+        'Information' { 
+            Write-Information -MessageData $logMessageFormatted -Tags @($serviceIdentifier, "Restart-Suite")
+        }
+        'Verbose' { 
+            Write-Verbose -Message $logMessageFormatted
+        }
+        'Debug' { 
+            Write-Debug -Message $logMessageFormatted
+        }
+        default { 
+            throw "Unknown log level: $_, but here is your message: $Message" 
+        }
+    }
+}

--- a/Register-WSL2-Backup.ps1
+++ b/Register-WSL2-Backup.ps1
@@ -3,6 +3,9 @@
 This script registers a scheduled task to perform a backup of a particular WSL2 distribution.
 .DESCRIPTION
 This script registers a scheduled task to perform a backup of a particular WSL2 distribution.
+
+Note: output redirection can be used to get a more informative output by exposing the log messages when appending '6>&1' 
+to the end of script invocation whether arguments are specified or not
 .EXAMPLE
 .\Register-WSL2-Backup.ps1 -destination D:\backups\wsl -distribution Ubuntu -dayOfWeek Tuesday -scheduledTime 2:30am -timeLimit (New-TimeSpan -Hours 4)
 .EXAMPLE
@@ -18,6 +21,11 @@ param(
     [ValidateNotNullOrEmpty()][timespan]$timeLimit = (New-TimeSpan -Hours 6),
     [string]$taskFolder = 'Custom Maintenance'
 )
+
+# 'sourcing' in the log message function
+. "$PSScriptRoot\Log-Message.ps1"
+
+Log "Starting to configure"
 $sanitizedUser = [regex]::Escape($user)
 $sanitizedDestination = [regex]::Escape($destination)
 
@@ -26,16 +34,21 @@ $taskDescription = "$taskName archived at or about $scheduledTime"
 
 $command = "-NoProfile -file $PSScriptRoot\WSL2-Backup.ps1 -distribution $distribution -destination $sanitizedDestination"
 $cmdExecutor = (Get-Command 'powershell').Definition
+Log "Done configuring"
 
-
+Log "Constructing new scheduled task parameters for the backup"
 $principle = New-ScheduledTaskPrincipal -UserId $sanitizedUser -LogonType  ServiceAccount
 $action = New-ScheduledTaskAction -Execute $cmdExecutor -Argument $command -WorkingDirectory $sanitizedDestination
 $settingsSet = New-ScheduledTaskSettingsSet -ExecutionTimeLimit $timeLimit -WakeToRun -StartWhenAvailable
 $trigger = New-ScheduledTaskTrigger -Weekly -WeeksInterval 1 -DaysOfWeek $dayOfWeek -At $scheduledTime
+Log "New scheduled task parameters for the backup constructed"
 
+Log "Registering the new scheduled task to perform the backup"
 Register-ScheduledTask -Action $action -Trigger $trigger -TaskPath $taskFolder -TaskName $taskName -Description $taskDescription -Principal $principle -Settings $settingsSet
+Log "The scheduled task to perform the backup is registered"
 
-$dockerRestartCommand = "-NoProfile -file $PSScriptRoot\Restart-Docker.ps1"
+Log "Constructing new scheduled task parameters for the restart of docker"
+$dockerRestartCommand = "-NoProfile -file $PSScriptRoot\Restart-Suite.ps1"
 $dockerRestartPrinciple = New-ScheduledTaskPrincipal -UserId "NT AUTHORITY\SYSTEM" -LogonType ServiceAccount
 $dockerRestartAction = New-ScheduledTaskAction -Execute $cmdExecutor -Argument $dockerRestartCommand
 $dockerRestartSettings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 10) -WakeToRun -StartWhenAvailable
@@ -55,5 +68,8 @@ $subscription = @"
 </QueryList>
 "@
 $dockerRestartTrigger.Subscription = $subscription
+Log "New scheduled task parameters for the restart constructed"
 
+Log "Registering the new scheduled task to perform the restart"
 Register-ScheduledTask -Action $dockerRestartAction -Trigger $dockerRestartTrigger -TaskPath $taskFolder -TaskName 'Restart Docker' -Description "Restart Docker on completion of '$taskName'" -Principal $dockerRestartPrinciple -Settings $dockerRestartSettings
+Log "The scheduled task to perform the restart is registered"

--- a/Restart-Suite.ps1
+++ b/Restart-Suite.ps1
@@ -4,6 +4,9 @@ This script restarts an application suite
 .DESCRIPTION
 This script restarts an application suite and by convention, docker is the suite the script was first designed and is targeted to.
 Gently messaged via [Restart docker Windows 10 command line](https://stackoverflow.com/a/57560043/549306)
+
+Note: output redirection can be used to get a more informative output by exposing the log messages when appending '6>&1' 
+to the end of script invocation whether arguments are specified or not
 .EXAMPLE
 .\Restart-Suite.ps1 -serviceTimeout 00:00:15
 #>
@@ -13,7 +16,7 @@ param (
     # Service identifier; a string to match against the list of system services
     [string]$serviceIdentifier = 'docker',
     # Service health check command
-    [string]$serviceHealthCommand = 'info',
+    [string]$serviceHealthCommand = 'docker info',
     # Client application name; note: omit including 'exe' as that will be appended within the script
     [string]$clientAppName = 'Docker Desktop',
     # host path to the client application; note: targeting path to 'docker' because 'docker desktop' is not
@@ -24,6 +27,10 @@ param (
     # a regular expression pattern that matches a variety of messages received when using the service health command while the service is still starting and not ready
     [string]$serviceStartupHealthMessagePattern = "error during connect|Error response from daemon"
 )
+
+# 'sourcing' in the log message function
+. "$PSScriptRoot\Log-Message.ps1"
+
 $clientAppPath = ''
 if (Test-Path $clientAppLocation) {
     $clientAppPath = $clientAppLocation | Join-Path -ChildPath "$clientAppName.exe"
@@ -32,60 +39,64 @@ else {
     $clientAppPath = "$clientAppName.exe"
 }
 
-$timestampFormat = 'HH:mm:ss'
 $stopped = [System.ServiceProcess.ServiceControllerStatus]::Stopped
 $running = [System.ServiceProcess.ServiceControllerStatus]::Running
 
-Write-Output "$((Get-Date).ToString($timestampFormat)) - Restarting $serviceIdentifier"
+Log "Restarting $serviceIdentifier"
 
 # note: some services may not be stopped due to a default lack of permissions and summarily throw a timeout error; elevated permissions are likely required
+Log "Stopping all services that match *$serviceIdentifier*"
 Get-Service -Name "*$serviceIdentifier*" | 
 Where-Object Status -ieq $running | 
 ForEach-Object {
-     Write-Output "Stopping service $($_.ServiceName)..."
-     Stop-Service -InputObject $_ -ErrorAction Continue -Confirm:$false -Force
-     $_.Refresh()
-     $_.WaitForStatus($stopped, $serviceTimeout)
-     $_.Refresh()
-     Write-Output "Service $($_.ServiceName) is $($_.Status)"
+    Log "`tStopping service $($_.ServiceName)..."
+    Stop-Service -InputObject $_ -ErrorAction Continue -Confirm:$false -Force
+    $_.Refresh()
+    $_.WaitForStatus($stopped, $serviceTimeout)
+    $_.Refresh()
+    Log "`tService $($_.ServiceName) is $($_.Status)"
 }
+Log "All services that match *$serviceIdentifier* should be stopped"
 
 # use wait-process (for longer process exits); if a dependant process is still shutting down during the restart of services, you will be left 
 # with a miscommunicating setup, so all processes must be stopped before a clean restart can occur
+Log "Stopping all processes that match *$clientAppName*"
 Get-Process -Name "*$clientAppName*" |
 ForEach-Object {
-    Write-Output "$($_.Name) with id of $($_.Id) will be stopped..."
+    Log "`t$($_.Name) with id of $($_.Id) will be stopped..."
     Stop-Process -InputObject $_
     Out-Null $_.WaitForExit(1000)
-    Write-Output "Process $($_.Name) with id of $($_.Id) is stopped."
+    Log "`tProcess $($_.Name) with id of $($_.Id) is stopped."
 }
+Log "All processes that match *$clientAppName* should have exited"
 
 # note: some sevices may not be started due to a default lack of permissions and summarily throw a timeout error; elevated permissions are likely required
+Log "Starting all services that match *$serviceIdentifier*"
 Get-Service -Name "*$serviceIdentifier*" | 
 Where-Object Status -ieq $stopped | 
 ForEach-Object {
-    Write-Output "Starting service $($_.ServiceName)..."
+    Log "`tStarting service $($_.ServiceName)..."
     $_.Start()
     $_.Refresh()
     $_.WaitForStatus($running, $serviceTimeout)
     $_.Refresh()
-    Write-Output "Service $($_.ServiceName) is $($_.Status)"
+    Log "`tService $($_.ServiceName) is $($_.Status)"
 }
+Log "All services that match *$serviceIdentifier* should be started"
 
 
-Write-Output "$((Get-Date).ToString($timestampFormat)) - Starting $clientAppName"
+Log "Starting $clientAppName"
 # call/invoke the application
 Start-Process -FilePath $clientAppPath -PassThru |
 ForEach-Object {
     $_.Refresh()
     do {
-        if ($_.HasExited -eq $true)
-        {
+        if ($_.HasExited -eq $true) {
             break;
         }
     } while ($_.WaitForInputIdle(1000) -ne $true)
-    Write-Output "$((Get-Date).ToString($timestampFormat)) - $clientAppName launched, but likely waiting for background services to finish starting up."
 }
+Log "$clientAppName launched, but likely waiting for background services to finish starting up before it is fully ready"
 
 $startTimeout = [DateTime]::Now.AddSeconds(90)
 $timeoutHit = $true
@@ -95,31 +106,31 @@ while ((Get-Date) -le $startTimeout) {
     Start-Sleep -Seconds 15
     $ErrorActionPreference = 'Continue'
     try {
-        $healthCheckResult = & $serviceIdentifier $serviceHealthCommand
-        Write-Output "$((Get-Date).ToString($timestampFormat)) - `tHealth command: $serviceIdentifier $serviceHealthCommand executed."
+        $healthCheckResult = $($serviceHealthCommand)
+        Log "`tHealth command: $serviceHealthCommand executed."
     
         if ($healthCheckResult -ilike '*error*') {
-            Write-Output "$((Get-Date).ToString($timestampFormat)) - `tHealth command: $serviceIdentifier $serviceHealthCommand had an error, but possibly not unexpected as services continue to finish starting; throwing..."
-            throw "Error running '$serviceIdentifier $serviceHealthCommand': $healthCheckResult"
+            Log "`tHealth command: $serviceHealthCommand had an error, but possibly not unexpected as services continue to finish starting; throwing..."
+            throw "Error running '$serviceHealthCommand': $healthCheckResult"
         }
-        Write-Output "$((Get-Date).ToString($timestampFormat)) - `tHealth command: $serviceIdentifier $serviceHealthCommand did not result in error, so presumably health and ready to use."
+        Log "`tHealth command: $serviceHealthCommand did not result in error, so presumably health and ready to use."
         $timeoutHit = $false
         break
     }
     catch {
     
-        if ($_ | Where-Object { $_ -match $serviceStartupHealthMessagePattern } | ForEach-Object { $Matches.Count -ge 1}) {
-            Write-Output "$((Get-Date).ToString($timestampFormat)) -`tService $serviceIdentifier startup not yet completed, waiting and checking again"
+        if ($_ | Where-Object { $_ -match $serviceStartupHealthMessagePattern } | ForEach-Object { $Matches.Count -ge 1 }) {
+            Log "`tService $serviceIdentifier startup not yet completed, waiting and checking again"
         }
         else {
-            Write-Error "Unexpected Error: `n $_"
+            Log "Unexpected Error: `n $_" -LogLevel Error
             throw "Unexpected Error: $_"
         }
     }
     $ErrorActionPreference = 'Stop'
 }
 if ($timeoutHit -eq $true) {
-    throw "Timeout waiting for $serviceIdentifier to startup"
+    throw "Timeout waiting for $serviceIdentifier to complete startup"
 }
 
-Write-Output "$((Get-Date).ToString($timestampFormat)) - $serviceIdentifier restarted"    
+Log "$serviceIdentifier restarted"    

--- a/WSL2-Backup.ps1
+++ b/WSL2-Backup.ps1
@@ -3,25 +3,33 @@
 This script performs a backup of a particular WSL2 distribution to a tar archive on the host system.
 .DESCRIPTION
 The script performs a backup using the WSL command of a given distribution.
+
+Note: output redirection can be used to get a more informative output by exposing the log messages when appending '6>&1' 
+to the end of script invocation whether arguments are specified or not
 .EXAMPLE
-.\WSLBackup.ps1 -distribution Ubuntu -destination $env:USERPROFILE\backups
+.\WSL2-Backup.ps1 -distribution Ubuntu -destination $env:USERPROFILE\backups
 .EXAMPLE
-.\WSLBackup.ps1 -distribution Ubuntu
+.\WSL2-Backup.ps1 -distribution Ubuntu
 #>
 param(
     [parameter(Mandatory = $true)][string]$destination,
-    [ValidateNotNullOrEmpty()][string]$distribution = 'Ubuntu',
-    [string]$dateFormatString = 'yyyyMMdd-hhmmss'
+    [ValidateNotNullOrEmpty()][string]$distribution = 'Ubuntu'
 )
+
+# 'sourcing' in the log message function
+. "$PSScriptRoot\Log-Message.ps1"
 
 # try to create the last segment of the path when the final segment does not exist but the parent does
 if (!(Test-Path $destination)) {
+    Log "Specified destination directory did not exist, attempting to create it."
     New-Item ($destination) -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 }
 
 $command = (Get-Command wsl).Definition
 # the backup command
-$dateExecuted = $((Get-Date).ToString($dateFormatString))
+$dateExecuted = $(Get-Date -Format FileDate)
 $commandArgs = "--export $distribution $destination\$distribution-$dateExecuted.tar"
 # execute the backup
+Log "Export of $distribution from WSL2 to a tar file saved in $destination starting"
 Invoke-Expression "& $command $commandArgs"
+Log "Export of $distribution from WSL2 to a tar file saved in $destination complete"


### PR DESCRIPTION
Besides introducing semi-consistent logging to the scripts, there was also a couple of stray bugs of consequence:

References to `Restart-Docker.ps1` changed to `Restart-Suite.ps1`

The `healthCheckCommand` is now expected to be completely specified instead of partially inferred and combined with the service name in the distinct liklihood that the service name will not also be the name of CLI tool to execute the health check.

One thing that needs to be corrected in a cursory review is the timestamp format is initially specified as a `FileDateTime`